### PR TITLE
Redesign AutologinSession

### DIFF
--- a/doc/weblogin.tex
+++ b/doc/weblogin.tex
@@ -40,8 +40,8 @@
 
 \input{intro.tex}
 \input{../src/weblogin/init.tex}
-\input{../src/weblogin/seamlessaccess.tex}
 \input{../src/weblogin/kth.tex}
+\input{../src/weblogin/seamlessaccess.tex}
 
 \printbibliography
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "weblogin"
-version = "0.3"
+version = "1.0"
 description = "Automates logging into web UIs to access unofficial APIs"
 authors = ["Daniel Bosk <dbosk@kth.se>"]
 license = "MIT"

--- a/src/weblogin/init.nw
+++ b/src/weblogin/init.nw
@@ -1,4 +1,4 @@
-\section{The [[AutologinSession]] abstract class}
+\section{The [[AutologinSession]] class}
 
 Here we document the [[weblogin]] main module.
 We provide an abstract class, [[weblogin.AutologinSession]], through which we 
@@ -12,25 +12,50 @@ The logging in will become completely invisible, as if it never happened.
 import requests
 
 <<exceptions>>
+<<classes>>
 
 class AutologinSession(requests.Session):
   """
   Maintains an authenticated session to a web system. This class intercepts any 
   requests made in a requests.Session and ensures that we log in when 
   redirected to the login page.
-
-  This is an abstract class.
   """
 
-  def __init__(self):
+  def __init__(self, handlers):
+    """
+    Takes a list of handlers. A handler should derive from AutologinHandler.
+    """
     super().__init__()
-    self.__logging_in = False
+    self.__handlers = handlers
 
-  def login(self, response, args=None, kwargs=None):
+  def request(self, *args, **kwargs):
+    """
+    Wrapper around requests.Session.request(...) to check we must log in.
+    """
+    response = super().request(*args, **kwargs)
+    
+    <<log in if necessary>>
+
+    return response
+@
+
+\subsection{The [[AutologinHandler]] abstract class}
+
+A handler should derive from this class:
+<<classes>>=
+class AutologinHandler:
+  """
+  An abstract class for a handler for the AutologinSession class.
+  """
+
+  def login(self, session, response, args=None, kwargs=None):
     """
     Performs a login based on the response from a request.
-    args and kwargs are the options from the request triggering the login 
-    procedure, this is so that we can redo that request after loggin in.
+    - `session` is an instance of requests.Session, most likely an instance of 
+      AutologinSession.
+    - `response` is the response of the latest request.
+    - `args` and `kwargs` are the options from the latest request, this is so 
+      that we can redo that request after logging in.
 
     Raises an AuthenticationError exception if authentication fails.
     """
@@ -39,35 +64,12 @@ class AutologinSession(requests.Session):
   def need_login(self, response):
     """
     Checks a response to determine if logging in is needed,
-    returns True if needed
+    returns True if needed.
     """
     raise NotImplementedError()
-
-  def request(self, *args, **kwargs):
-    """
-    Wrapper around requests.Session.request(...) to check if logging in
-    is needed.
-    """
-    response = super().request(*args, **kwargs)
-    
-    <<check if we need to log in>>
-
-    return response
 @
 
-Checking if we need to log in is a bit tricky.
-Any request we make to the login service, will also be intercepted.
-This is why we need the [[self.__logging_in]] attribute, to temporarily turn 
-this interception off.
-<<check if we need to log in>>=
-if not self.__logging_in and self.need_login(response):
-  self.__logging_in = True
-  response = self.login(response, args, kwargs)
-  self.__logging_in = False
-@
-
-
-\section{Errors}
+\subsection{Errors}
 
 We must report authentication errors.
 For this we need specialized exceptions.
@@ -76,3 +78,17 @@ class AuthenticationError(Exception):
   pass
 @
 
+\subsection{Log in if necessary}
+
+The login procedure is quite straightforward, we simply call each handler.
+Each handler will itself keep track of state if they require several steps when 
+logging in.
+Each handler will possibly update the response for the next handler.
+<<log in if necessary>>=
+for handler in self.__handlers:
+  if handler.need_login(response):
+    response = handler.login(session, response, args, kwargs)
+@
+
+The benefit of this design comes when trying to log in using an SSO:
+We first have a handler for the main service and another handler for the SSO.

--- a/src/weblogin/init.nw
+++ b/src/weblogin/init.nw
@@ -87,7 +87,7 @@ Each handler will possibly update the response for the next handler.
 <<log in if necessary>>=
 for handler in self.__handlers:
   if handler.need_login(response):
-    response = handler.login(session, response, args, kwargs)
+    response = handler.login(self, response, args, kwargs)
 @
 
 The benefit of this design comes when trying to log in using an SSO:

--- a/src/weblogin/kth.nw
+++ b/src/weblogin/kth.nw
@@ -1,35 +1,35 @@
 \section{Logging in at KTH}
 
 Here we provide the module [[weblogin.kth]], which serves as an example of how 
-to use [[weblogin]].
+to write a login handler for use with [[weblogin.AutologinSession]].
 
 We need a class for KTH that detects logins at KTH.
-Then we implement the missing methods in the [[weblogin.AutologinSession]] 
+Then we implement the missing methods in the [[weblogin.AutologinHandler]] 
 class.
 <<kth.py>>=
 from lxml import html
 import requests
 import weblogin
 
-LOGIN_SERVER = "login.ug.kth.se"
-
-class AutologinSession(weblogin.AutologinSession):
+class UGlogin(weblogin.AutologinHandler):
   """
-  requests.Session replacement to ensure all requests are automatically logged 
-  in at KTH.
+  Login handler (weblogin.AutologinHandler) for UG logins, i.e. through 
+  login.ug.kth.se.
   """
+  LOGIN_URL = "https://login.ug.kth.se"
   
   def __init__(self, username, password, login_trigger_url=None):
     """
-    Creates a requests.Session that automatically logs into KTH.
-    Requires username and password.
-    Optional login_trigger_url is a page that redirects to the login page,
-    for instance, the API URLs don't redirect, but the UI URLs do.
+    Creates a login handler that automatically logs into KTH.
+    - Requires username and password.
+    - Optional `login_trigger_url` is a page that redirects to the login page,
+      for instance, the API URLs don't redirect, but the UI URLs do.
     """
     super().__init__()
     self.__username = username
     self.__password = password
     self.__login_trigger_url = login_trigger_url
+    self.__logging_in = False
 
   def need_login(self, response):
     """
@@ -38,16 +38,24 @@ class AutologinSession(weblogin.AutologinSession):
     """
     <<check if we're redirected to login server>>
 
-  def login(self, response, args=None, kwargs=None):
+  def login(self, session, response, args=None, kwargs=None):
     """
-    Performs a login based on the response from a request
-    args and kwargs are the options from the request triggering the login 
-    procedure, this is so that we can redo that request after loggin in.
+    Performs a login based on the response `response` from a request to session 
+    `session`.
+    `args` and `kwargs` are the options from the request triggering the login 
+    procedure, this is so that we can redo that request after logging in.
 
     Raises an AuthenticationError exception if authentication fails.
     """
+    self.__logging_in = True
     <<log in to login server>>
+    self.__logging_in = False
 @
+
+We note that while we're logging in, we don't want those requests interrupted 
+by another login session.
+Hence, we block any new login procedures from starting by setting 
+[[self.__logging_in]].
 
 \subsection{Check if we need to log in at KTH}
 
@@ -58,10 +66,15 @@ There are two cases:
 \end{enumerate}
 Thus, we can detect this with either the return code or if the URL starts with 
 the URL to the login service, then we need to log in.
+However, as noted above, this only applies if we're not already underway with a 
+login.
 <<check if we're redirected to login server>>=
+if self.__logging_in:
+  return False
+
 return (response.status_code == requests.codes.unauthorized and \
           "kth.se" in response.url) or \
-        response.url.find(f"https://{LOGIN_SERVER}") == 0
+       response.url.find(self.LOGIN_URL) == 0
 @
 
 \subsection{Log in at KTH}\label{LoginAtKTH}
@@ -102,8 +115,8 @@ data["UserName"] = self.__username if "@ug.kth.se" in self.__username \
 data["Password"] = self.__password
 data["Kmsi"] = True
 
-new_response = self.request(
-  form.method, f"https://{LOGIN_SERVER}/{form.action}",
+new_response = session.request(
+  form.method, f"{self.LOGIN_URL}/{form.action}",
   data=data)
 
 if new_response.status_code != requests.codes.ok:
@@ -121,9 +134,9 @@ can log in using the method above.
 When we've done that, we must re-run the original request (the one that didn't 
 trigger a redirect) and return the reply from the new request.
 <<trigger redirect to login page>>=
-new_response = self.get(self.__login_trigger_url)
-login_response = self.login(new_response)
-request_response = self.request(*args, **kwargs)
+new_response = session.get(self.__login_trigger_url)
+login_response = self.login(session, new_response)
+request_response = session.request(*args, **kwargs)
 
 if request_response.status_code == requests.codes.unauthorized:
   raise AuthenticationError(f"authentication apparently failed: "
@@ -133,7 +146,7 @@ return request_response
 @
 
 
-\section{Tests}
+\subsection{Tests}
 
 It's hard to test the functionality.
 We basically want to test if the API on the other side still works.
@@ -145,22 +158,25 @@ the redirect ourselves using the [[login_trigger_url]].
 
 The two tests follow.
 <<test kth.py>>=
-from weblogin.kth import AutologinSession
+from weblogin import AutologinSession
+from weblogin.kth import UGlogin
 import os
 import requests
 
 def test_get_ui():
-  ug = AutologinSession(os.environ["KTH_LOGIN"],
-                        os.environ["KTH_PASSWD"],
-                        "https://app.kth.se/ug-gruppeditor/")
+  ug = AutologinSession([
+    UGlogin(os.environ["KTH_LOGIN"], os.environ["KTH_PASSWD"],
+            "https://app.kth.se/ug-gruppeditor/")
+    ])
   response = ug.get("https://app.kth.se/ug-gruppeditor/")
   assert response.status_code == requests.codes.ok and \
     response.url.find("https://app.kth.se") == 0
 
 def test_get_api():
-  ug = AutologinSession(os.environ["KTH_LOGIN"],
-                        os.environ["KTH_PASSWD"],
-                        "https://app.kth.se/ug-gruppeditor/")
+  ug = AutologinSession([
+    UGlogin(os.environ["KTH_LOGIN"], os.environ["KTH_PASSWD"],
+            "https://app.kth.se/ug-gruppeditor/")
+    ])
   response = ug.get("https://app.kth.se/ug-gruppeditor/api/ug/groups"
                     "?editableBySelf=true")
   assert response.status_code == requests.codes.ok and response.json()


### PR DESCRIPTION
This changes the design from using inheritance to adding login handlers. This way we can add several login handlers linking them together, for instance: one for LADOK+SeamlessAccess, one for KTH SAML and one for KTH UG. All of which are needed to log into LADOK, but only the last is needed to access the UG Editor API.